### PR TITLE
Created SpecUtil to handle common api request config and common assertions.

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -1,16 +1,13 @@
 package com.api.tests;
 
+import static com.api.constant.Role.*;
 import static io.restassured.RestAssured.*;
 import static io.restassured.module.jsv.JsonSchemaValidator.*;
 import static org.hamcrest.Matchers.*;
 
 import org.testng.annotations.Test;
 
-import com.api.constant.Role;
-import com.api.utils.AuthTokenProvider;
-import com.api.utils.ConfigManager;
-
-import io.restassured.http.ContentType;
+import com.api.utils.SpecUtil;
 
 public class CountAPITest {
 	
@@ -19,20 +16,11 @@ public class CountAPITest {
 	public void verifyCountAPIResponse() {
 		
 		given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.accept(ContentType.JSON)
-		.header("Authorization", AuthTokenProvider.getToken(Role.FD))
-		.log().method()
-		.log().uri()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.get("/dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(1500L))
+		.spec(SpecUtil.responseSpec_OK())
 		.body("message", equalTo("Success"))
 		.body("data", notNullValue())
 		.body("data.size()", equalTo(3))
@@ -46,18 +34,11 @@ public class CountAPITest {
 	public void verifyCountAPI_MissingAuthToken() {
 		
 		given()
-		.baseUri(ConfigManager.getProperty("BASE_URI"))
-		.and()
-		.accept(ContentType.JSON)
-		.log().method()
-		.log().uri()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.get("/dashboard/count")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -6,9 +6,8 @@ import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
-import static com.api.utils.ConfigManager.*;
+import com.api.utils.SpecUtil;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class LoginAPITest {
@@ -19,27 +18,15 @@ public class LoginAPITest {
 		UserCredentials userCrendentials= new UserCredentials("iamfd", "password");
 		
 		given()
-			.baseUri(getProperty("BASE_URI"))
-		.and()
-			.contentType(ContentType.JSON)
-		.and()
-			.accept(ContentType.JSON)
-		.and()
-			.body(userCrendentials)
-			.log().uri()
-			.log().method()
-			.log().headers()
-			.log().body()
+		.spec(SpecUtil.requestSpec(userCrendentials))
 		.when()
-			.post("login")
+		.post("login")
 		.then()
-			.log().all()
-			.statusCode(200)
-			.time(lessThan(1600L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
-			.body("message", equalTo("Success"))
+		.body("message", equalTo("Success"))
 		.and()
-			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/loginResponseSchema.json"));
+		.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/loginResponseSchema.json"));
 
 }
 }

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -1,14 +1,14 @@
 package com.api.tests;
 
-import static com.api.constant.Role.FD;
-import static com.api.utils.AuthTokenProvider.*;
-import static com.api.utils.ConfigManager.*;
+import static com.api.constant.Role.*;
 import static io.restassured.RestAssured.*;
+import static io.restassured.module.jsv.JsonSchemaValidator.*;
 import static org.hamcrest.Matchers.*;
+
 
 import org.testng.annotations.Test;
 
-import static io.restassured.module.jsv.JsonSchemaValidator.*;
+import com.api.utils.SpecUtil;
 
 public class MasterAPITest {
 	
@@ -16,20 +16,11 @@ public class MasterAPITest {
 	public void masterAPITest() {
 		
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.contentType("")
-		.header("Authorization", getToken(FD))
-		.log().method()
-		.log().uri()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(1500L))
+		.spec(SpecUtil.responseSpec_OK())
 		.body("message", equalTo("Success"))
 		.body("data", notNullValue())
 		.body("data", hasKey("mst_oem"))
@@ -47,18 +38,11 @@ public class MasterAPITest {
 	public void invalidTokenMasterAPITest() {
 		
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-		.contentType("")
-		.log().method()
-		.log().uri()
-		.log().body()
-		.log().headers()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.post("master")
 		.then()
-		.log().all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -1,16 +1,12 @@
 package com.api.tests;
 
-import static com.api.utils.AuthTokenProvider.getToken;
-import static com.api.utils.ConfigManager.getProperty;
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.lessThan;
+import static com.api.constant.Role.*;
+import static io.restassured.RestAssured.*;
 
 import org.testng.annotations.Test;
 
-import static com.api.constant.Role.*;
+import com.api.utils.SpecUtil;
 
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import io.restassured.module.jsv.JsonSchemaValidator;
 
 public class UserDetailsAPITest {
@@ -18,24 +14,12 @@ public class UserDetailsAPITest {
 	@Test
 	public void userDetailsAPIRequest() {
 		
-		Header authHeader = new Header("Authorization", getToken(SUP));
-		
 		given()
-		.baseUri(getProperty("BASE_URI"))
-		.and()
-			.header(authHeader)
-		.and()
-			.accept(ContentType.JSON)
-			.log().uri()
-			.log().method()
-			.log().headers()
-			.log().body()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 			.get("userdetails")
 		.then()
-			.log().all()
-			.statusCode(200) //
-			.time(lessThan(1600L))
+		.spec(SpecUtil.responseSpec_OK())
 		.and()
 			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/userDetailsResponseSchema.json"));
 	}

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,101 @@
+package com.api.utils;
+
+import static com.api.utils.ConfigManager.getProperty;
+
+import org.hamcrest.Matchers;
+
+import com.api.constant.Role;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+	
+	
+	public static RequestSpecification requestSpec() {
+		
+		RequestSpecification requestSpecification= new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+	}
+	
+	public static RequestSpecification requestSpec(Object userCreds) {
+		
+		RequestSpecification requestSpecification= new RequestSpecBuilder()
+		.setBaseUri(getProperty("BASE_URI"))
+		.setContentType(ContentType.JSON)
+		.setAccept(ContentType.JSON)
+		.setBody(userCreds)
+		.log(LogDetail.URI)
+		.log(LogDetail.METHOD)
+		.log(LogDetail.HEADERS)
+		.log(LogDetail.BODY)
+		.build();
+		
+		return requestSpecification;
+	}
+	
+	
+	public static RequestSpecification requestSpecWithAuth(Role role) {
+		RequestSpecification requestSpecification= new RequestSpecBuilder()
+				.setBaseUri(getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.addHeader("Authorization", AuthTokenProvider.getToken(role))			
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+				
+				return requestSpecification;
+	}
+	
+	public static ResponseSpecification responseSpec_OK() {
+		
+		ResponseSpecification responseSpecification= new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(200)
+		.expectResponseTime(Matchers.lessThan(1600L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+	public static ResponseSpecification responseSpec_JSON(int statusCode) {
+		
+		ResponseSpecification responseSpecification= new ResponseSpecBuilder()
+		.expectContentType(ContentType.JSON)
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1600L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+	
+public static ResponseSpecification responseSpec_TEXT(int statusCode) {
+		
+		ResponseSpecification responseSpecification= new ResponseSpecBuilder()
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1600L))
+		.log(LogDetail.ALL)
+		.build();
+		
+		return responseSpecification;
+	}
+
+}


### PR DESCRIPTION
SpecUtil consisting of common RequestSpecBuilder and  ResponseSpecBuilder. These method has reduced boiler plate code in our api tests, and also reduced the number of lines. Making test code smaller and maintainable